### PR TITLE
Fix Launchpad parser offset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,8 @@ pub fn parse_launchpad_pool_state(data: &[u8]) -> Result<JsValue, JsValue> {
     off += 8 * 8;
 
     let global_config = read_pubkey(buf, &mut off)?;
-    off += 32;
+    // skip platform_config and base_mint (2 pubkeys)
+    off += 32 * 2;
     let quote_mint = read_pubkey(buf, &mut off)?;
 
     // Build JS object with key fields


### PR DESCRIPTION
## Summary
- skip platform_config and base_mint so the quote mint is parsed correctly

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_683f7ff2841083299bb6dae8604e6978