### PR TITLE
Automate build output copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ cd meme-decoder
 
 ## Build the WebAssembly package
 
-`wasm-pack build --target web`
+Run `npm run build` to compile the WASM package. If a `../meme-farmer` directory
+exists next to `meme-decoder`, the build script also copies the generated `pkg/`
+folder there.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A WebAssembly (WASM) library for decoding Solana meme token creation instructions from various platforms.",
   "main": "pkg/meme_decoder.js",
   "scripts": {
-    "build": "wasm-pack build --target web --out-dir pkg --release"
+    "build": "wasm-pack build --target web --out-dir pkg --release && if [ -d ../meme-farmer ]; then rm -rf ../meme-farmer/pkg && cp -r pkg ../meme-farmer/pkg; fi"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- copy build artifacts to `../meme-farmer/pkg` when `npm run build` executes
- describe the new build behaviour in the README

## Testing
- `npm run build` *(fails: could not download wasm32 target)*

------
https://chatgpt.com/codex/tasks/task_e_684040d734d88329b18762b2f92f3172